### PR TITLE
drift 时先在目标节点预热镜像，然后再 stop container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 lain_admin_cli.egg-info
 *DS_Store
+build/
+dist/

--- a/lain_admin_cli/drift.py
+++ b/lain_admin_cli/drift.py
@@ -123,8 +123,6 @@ def warm_up_on_target(playbooks_path, containers, source, target):
     cmd = ['ansible-playbook', '-i', os.path.join(playbooks_path, 'cluster')]
     cmd += ['-e', 'target=nodes']
     cmd += ['-e', 'target_node=%s' % target.name]
-    cmd += ['-e', 'from_node=%s' % source.name]
-    cmd += ['-e', 'from_ip=%s' % source.ip]
     cmd += ['-e', 'role=drift-warm-up']
     cmd += ['-e', 'to_drift_images=%s' % to_drift_images]
     cmd += [os.path.join(playbooks_path, 'role.yaml')]

--- a/lain_admin_cli/drift.py
+++ b/lain_admin_cli/drift.py
@@ -152,6 +152,10 @@ def drift_container(from_node, container, to_node, playbooks_path, with_volume, 
     url += "&force=true" if with_volume or ignore_volume else ""
     url += "&to=%s" % to_node.name if to_node else ""
 
+    ## Warm-up on target node
+    info("Warm-up on target node...")
+    warm_up_on_target(playbooks_path, [container], from_node, to_node)
+
     ## Drift volumes
     if with_volume and len(container.volumes) > 0:
         info("Drift the volume...")
@@ -167,10 +171,6 @@ def drift_container(from_node, container, to_node, playbooks_path, with_volume, 
 
         info("Drift the volume again...")
         drift_volumes(playbooks_path, [container], from_node, to_node)
-
-    ## Warm-up on target node
-    info("Warm-up on target node...")
-    warm_up_on_target(playbooks_path, [container], from_node, to_node)
 
     ## Call deployd api
     info("PATCH %s" % url)

--- a/lain_admin_cli/drift.py
+++ b/lain_admin_cli/drift.py
@@ -2,8 +2,8 @@
 
 from argh.decorators import arg
 from lain_admin_cli.helpers import Node, Container, is_backupd_enabled
-from lain_admin_cli.helpers import yes_or_no, info, error, warn, _yellow, get_domain, volume_dir
-from subprocess import check_output, check_call, CalledProcessError, STDOUT
+from lain_admin_cli.helpers import yes_or_no, info, error, warn, _yellow, volume_dir
+from subprocess import check_output, check_call, CalledProcessError
 import requests, os, json, time
 
 
@@ -44,7 +44,7 @@ def drift(containers, with_volume=False, ignore_volume=False, playbooks="", targ
 
         node = Node(container.host)
         drift_container(node, container, target, playbooks, with_volume, ignore_volume)
-        if len(c.volumes) > 0 and is_backupd_enabled():
+        if len(container.volumes) > 0 and is_backupd_enabled():
             fix_backupd(container, node, target)
 
 
@@ -116,6 +116,22 @@ def drift_volumes(playbooks_path, containers, source, target):
     os.remove(var_file)
 
 
+def warm_up_on_target(playbooks_path, containers, source, target):
+    to_drift_images = reduce(lambda x, y: x + [y.info['Config']['Image']],
+                             containers, [])
+
+    cmd = ['ansible-playbook', '-i', os.path.join(playbooks_path, 'cluster')]
+    cmd += ['-e', 'target=nodes']
+    cmd += ['-e', 'target_node=%s' % target.name]
+    cmd += ['-e', 'from_node=%s' % source.name]
+    cmd += ['-e', 'from_ip=%s' % source.ip]
+    cmd += ['-e', 'role=drift-warm-up']
+    cmd += ['-e', 'to_drift_images=%s' % to_drift_images]
+    cmd += [os.path.join(playbooks_path, 'role.yaml')]
+    info('cmd is: %s', ' '.join(cmd))
+    check_call(cmd)
+
+
 def drift_container(from_node, container, to_node, playbooks_path, with_volume, ignore_volume):
     if container.appname == 'deploy':
         key = '/lain/deployd/pod_groups/deploy/deploy.web.web'
@@ -151,6 +167,10 @@ def drift_container(from_node, container, to_node, playbooks_path, with_volume, 
 
         info("Drift the volume again...")
         drift_volumes(playbooks_path, [container], from_node, to_node)
+
+    ## Warm-up on target node
+    info("Warm-up on target node...")
+    warm_up_on_target(playbooks_path, [container], from_node, to_node)
 
     ## Call deployd api
     info("PATCH %s" % url)


### PR DESCRIPTION
# 起因

drift 时如果目标节点没有镜像，那么部署的时候需要先拉取镜像，要花费较长的时间，所以容器停止的时间较长，不利于生产环境下的无缝迁移。
# 经过

加了 ansible 脚本，如果目标节点没有镜像的话先拉取镜像，再停止容器，再部署，极大地缩短了服务中断时间。
# 结果（使用 [go-blog-on-lain](https://github.com/kaizhang-shanxi/go-blog-on-lain/tree/with-entrypoint) 测试，没计算 `drift volumes` 的时间）
- 不预热且目标节点没有镜像时，部署要花 56.67 秒；
- 预热时，先拉取镜像（41.13 秒），再停止容器，再部署（12 秒）。

相当于服务中断时间缩短了 41.13 秒。
# 备注

*\* 重要**：请先合并 [https://github.com/laincloud/lain/pull/78](https://github.com/laincloud/lain/pull/78)，再合并此 pr。
